### PR TITLE
conda environment creation error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -52,7 +52,7 @@ dependencies:
       - exceptiongroup==1.2.0
       - fastapi==0.105.0
       - filelock==3.13.1
-      - flash-attn==2.3.6
+      # - flash-attn==2.3.6
       - frozenlist==1.4.1
       - fsspec==2023.10.0
       - google-auth==2.25.2

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+conda env create -f environment.yml
+
+conda activate selfrag
+
+# Install flash-attn package
+pip3 install flash-attn==2.3.6


### PR DESCRIPTION
Hi, When I use conda to config the env with `conda env create -f environment.yml`, I got some error:

```
(base) e@hello-there:~/self-rag$ conda env create -f environment.yml
Channels:
 - nvidia/label/cuda-12.1.0
 - defaults
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: done

Downloading and Extracting Packages:

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
Installing pip dependencies: - Ran pip subprocess with arguments:
['/home/e/miniconda3/envs/selfrag/bin/python', '-m', 'pip', 'install', '-U', '-r', '/home/e/self-rag/condaenv.sff2oxry.requirements.txt', '--exists-action=b']
Pip subprocess output:
Collecting absl-py==2.0.0 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 1))
  Using cached absl_py-2.0.0-py3-none-any.whl.metadata (2.3 kB)
Collecting accelerate==0.25.0 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 2))
  Using cached accelerate-0.25.0-py3-none-any.whl.metadata (18 kB)
Collecting aiohttp==3.9.1 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 3))
  Using cached aiohttp-3.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (7.4 kB)
Collecting aioprometheus==23.3.0 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 4))
  Using cached aioprometheus-23.3.0-py3-none-any.whl.metadata (9.8 kB)
Collecting aiosignal==1.3.1 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 5))
  Using cached aiosignal-1.3.1-py3-none-any.whl.metadata (4.0 kB)
Collecting anyio==3.7.1 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 6))
  Using cached anyio-3.7.1-py3-none-any.whl.metadata (4.7 kB)
Collecting async-timeout==4.0.3 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 7))
  Using cached async_timeout-4.0.3-py3-none-any.whl.metadata (4.2 kB)
Collecting attrs==23.1.0 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 8))
  Using cached attrs-23.1.0-py3-none-any.whl.metadata (11 kB)
Collecting bitsandbytes==0.41.3.post2 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 9))
  Using cached bitsandbytes-0.41.3.post2-py3-none-any.whl.metadata (9.8 kB)
Collecting blis==0.7.11 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 10))
  Using cached blis-0.7.11-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (7.4 kB)
Collecting cachetools==5.3.2 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 11))
  Using cached cachetools-5.3.2-py3-none-any.whl.metadata (5.2 kB)
Collecting catalogue==2.0.10 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 12))
  Using cached catalogue-2.0.10-py3-none-any.whl.metadata (14 kB)
Collecting certifi==2023.11.17 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 13))
  Using cached certifi-2023.11.17-py3-none-any.whl.metadata (2.2 kB)
Collecting charset-normalizer==3.3.2 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 14))
  Using cached charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (33 kB)
Collecting click==8.1.7 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 15))
  Using cached click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
Collecting cloudpathlib==0.16.0 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 16))
  Using cached cloudpathlib-0.16.0-py3-none-any.whl.metadata (14 kB)
Collecting colorama==0.4.6 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 17))
  Using cached colorama-0.4.6-py2.py3-none-any.whl.metadata (17 kB)
Collecting confection==0.1.4 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 18))
  Using cached confection-0.1.4-py3-none-any.whl.metadata (19 kB)
Collecting cymem==2.0.8 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 19))
  Using cached cymem-2.0.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (8.4 kB)
Collecting dataclasses==0.6 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 20))
  Using cached dataclasses-0.6-py3-none-any.whl (14 kB)
Collecting datasets==2.15.0 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 21))
  Using cached datasets-2.15.0-py3-none-any.whl.metadata (20 kB)
Collecting deepspeed==0.12.6 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 22))
  Using cached deepspeed-0.12.6.tar.gz (1.2 MB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Collecting dill==0.3.7 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 23))
  Using cached dill-0.3.7-py3-none-any.whl.metadata (9.9 kB)
Collecting einops==0.7.0 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 24))
  Using cached einops-0.7.0-py3-none-any.whl.metadata (13 kB)
Collecting evaluate==0.4.1 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 25))
  Using cached evaluate-0.4.1-py3-none-any.whl.metadata (9.4 kB)
Collecting exceptiongroup==1.2.0 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 26))
  Using cached exceptiongroup-1.2.0-py3-none-any.whl.metadata (6.6 kB)
Collecting fastapi==0.105.0 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 27))
  Using cached fastapi-0.105.0-py3-none-any.whl.metadata (24 kB)
Collecting filelock==3.13.1 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 28))
  Using cached filelock-3.13.1-py3-none-any.whl.metadata (2.8 kB)
Collecting flash-attn==2.3.6 (from -r /home/e/self-rag/condaenv.sff2oxry.requirements.txt (line 29))
  Using cached flash_attn-2.3.6.tar.gz (2.3 MB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'

Pip subprocess error:
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-losvbsvr/flash-attn_b965b20d25f3455ab48f0ce200c5002d/setup.py", line 9, in <module>
          from packaging.version import parse, Version
      ModuleNotFoundError: No module named 'packaging'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

failed

CondaEnvException: Pip failed
```

I tried to add `packaging` in the dependency, but not working, then I tried to install `flash-attn` after conda env creation, and it worked. Maybe you could check this and see what happens, this happened on both my PC (ubuntu 22.04) and server (ubuntu 20.04), hope this could help.